### PR TITLE
Use grunt serve because grunt server is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ on running Groonga Admin.
 
 Run Groonga Admin:
 
-    % grunt server
+    % grunt serve
 
 If you want to use Groonga HTTP server run on `groonga.example.com`,
 run Groonga Admin as by the following command line:
 
-    % GROONGA_HOST=groonga.example.com grunt server
+    % GROONGA_HOST=groonga.example.com grunt serve


### PR DESCRIPTION
  Running "server" task
  >> The `server` task has been deprecated. Use `grunt serve` to start a server.