### PR TITLE
Fix failure about grunt serve task

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt": "^0.4.1",
     "grunt-autoprefixer": "^0.7.3",
     "grunt-concurrent": "^0.5.0",
-    "grunt-connect-proxy": "^0.1.11",
+    "grunt-connect-proxy": "^0.2.0",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-compass": "^0.7.2",
     "grunt-contrib-concat": "^0.4.0",


### PR DESCRIPTION
  % grunt serve
  Loading "connect_proxy.js" tasks...ERROR
  >> TypeError: The super constructor to `inherits` must not be null or undefined.

  Running "serve" task
  Warning: Task "configureProxies:server" not found. Use --force to continue.

  Aborted due to warnings.

See related issue about "Grunt serve doesn't work anymore"
  https://github.com/gruntjs/grunt/issues/1315